### PR TITLE
Автоматическое преобразование CRLF в LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
-* text eol=lf
+* text=auto
+
+# Приводит все переводы строк в текстовых файлах к символу LF
+*.{php,md,json,gitignore,gitattributes} text eol=lf


### PR DESCRIPTION
Директивы в файле `.gitattributes` заставляют git заменять все переносы строк в текстовых файлах на LF во время коммита.  Подробнее тут: https://help.github.com/articles/dealing-with-line-endings/.